### PR TITLE
add ThisOutlookSession.cls that intercepts the standard reply buttons…

### DIFF
--- a/ThisOutlookSession.cls
+++ b/ThisOutlookSession.cls
@@ -1,0 +1,31 @@
+Option Explicit
+Private WithEvents oExpl As Explorer
+Private WithEvents oItem As mailitem
+
+Private Sub Application_Startup()
+  Set oExpl = Application.ActiveExplorer
+End Sub
+
+Private Sub oExpl_SelectionChange()
+  On Error Resume Next
+  Set oItem = oExpl.Selection.item(1)
+End Sub
+
+Private Sub oItem_Reply(ByVal Response As Object, Cancel As Boolean)
+   'QuoteFixMacro will open _a new_ reply, therefore the original one will be _always_ cancelled
+   Cancel = True
+   Call QuoteFixMacro.FixedReply
+End Sub
+
+Private Sub oItem_ReplyAll(ByVal Response As Object, Cancel As Boolean)
+   'QuoteFixMacro will open _a new_ reply, therefore the original one will be _always_ cancelled
+   Cancel = True
+   Call QuoteFixMacro.FixedReplyAll
+   'Call QuoteFixMacro.FixedReplyAllEnglish
+End Sub
+
+Private Sub oItem_Forward(ByVal Response As Object, Cancel As Boolean)
+   'QuoteFixMacro will open _a new_ reply, therefore the original one will be _always_ cancelled
+   Cancel = True
+   Call QuoteFixMacro.FixedForward
+End Sub


### PR DESCRIPTION
… and calls OutlookQuoteFix instead

Add this file's content to 'ThisOutlookSession' in the Outlook Visual Basic Macro Editor after having installed QuoteFixMacro and restart Outlook. You can then use the normal Reply/ReplyAll/Forward buttons. No need to add custom Buttons to the menubar. Currently a separate button for "ReplyAllEnglish" is required using the previous method as described in README.md.

This also works with the standard reply buttons that appear in the reading pane. It should also work if the reply event is triggered otherwise (e.g. by another macro) but I have not tested this.

(This is the result of much googling and trial-and-error as I do not have any deep knowledge of VBA. Feel free to improve before merging)