### PR TITLE
ensure an empty line is kept after the header for forwarded mails

### DIFF
--- a/QuoteFixMacro.bas
+++ b/QuoteFixMacro.bas
@@ -1349,7 +1349,7 @@ Private Function getOutlookHeader(ByRef BodyLines() As String, ByRef lineCounter
     Next lineCounter
 
     'skip OUTLOOK_HEADERFINISH
-    lineCounter = lineCounter + 1
+    'lineCounter = lineCounter + 1
 
 End Function
 

--- a/ThisOutlookSession.cls
+++ b/ThisOutlookSession.cls
@@ -1,0 +1,31 @@
+Option Explicit
+Private WithEvents oExpl As Explorer
+Private WithEvents oItem As mailitem
+
+Private Sub Application_Startup()
+  Set oExpl = Application.ActiveExplorer
+End Sub
+
+Private Sub oExpl_SelectionChange()
+  On Error Resume Next
+  Set oItem = oExpl.Selection.item(1)
+End Sub
+
+Private Sub oItem_Reply(ByVal Response As Object, Cancel As Boolean)
+   'QuoteFixMacro will open _a new_ reply, therefore the original one will be _always_ cancelled
+   Cancel = True
+   Call QuoteFixMacro.FixedReply
+End Sub
+
+Private Sub oItem_ReplyAll(ByVal Response As Object, Cancel As Boolean)
+   'QuoteFixMacro will open _a new_ reply, therefore the original one will be _always_ cancelled
+   Cancel = True
+   Call QuoteFixMacro.FixedReplyAll
+   'Call QuoteFixMacro.FixedReplyAllEnglish
+End Sub
+
+Private Sub oItem_Forward(ByVal Response As Object, Cancel As Boolean)
+   'QuoteFixMacro will open _a new_ reply, therefore the original one will be _always_ cancelled
+   Cancel = True
+   Call QuoteFixMacro.FixedForward
+End Sub


### PR DESCRIPTION
This makes the whole thing much more readable as you can easily see where the header ends and where the content starts.